### PR TITLE
Updated the cli commands for FSx root squash

### DIFF
--- a/doc_source/root-squash.md
+++ b/doc_source/root-squash.md
@@ -51,10 +51,8 @@ You can enable root squash when creating a new Amazon FSx for Lustre file system
         --client-request-token CRT1234 \
         --file-system-type LUSTRE \
         --file-system-type-version 2.12 \
-        --lustre-configuration DeploymentType=PERSISTENT_2,PerUnitStorageThroughput=200,DataCompressionType=LZ4 \
-            RootSquashConfiguration={RootSquash="65534:65534", \
-            NoSquashNids=["10.216.123.47@tcp", "10.216.12.176@tcp"]} \
-        --storage-capacity 3600 \
+        --lustre-configuration DeploymentType=PERSISTENT_2,PerUnitStorageThroughput=125,DataCompressionType=LZ4,RootSquashConfiguration='{RootSquash="65534:65534", NoSquashNids=["10.216.123.47@tcp", "10.216.12.176@tcp"]}' \
+        --storage-capacity 1200 \
         --subnet-ids subnet-123456 \
         --tags Key=Name,Value=Lustre-TEST-1 \
         --region us-east-2
@@ -119,8 +117,7 @@ This command specifies that root squash is enabled using `65534` as the value fo
 ```
 $ aws fsx update-file-system \
     --file-system-id fs-0123456789abcdef0 \
-    --lustre-configuration RootSquashConfiguration={RootSquash="65534:65534", \
-          NoSquashNids=["10.216.123.47@tcp", "10.216.12.176@tcp"]}
+    --lustre-configuration RootSquashConfiguration='{RootSquash="65534:65534", NoSquashNids=["10.216.123.47@tcp", "10.216.12.176@tcp"]}'
 ```
 
 If the command is successful, Amazon FSx for Lustre returns the response in JSON format\.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updated command fixes cli issues with RootSquashConfiguration (described below) and includes correct values for PerUnitStorageThroughput as well as storage-capacity.

```
[cloudshell-user@ip-10-0-112-5 ~]$  aws fsx create-file-system \
>       --client-request-token CRT1234 \
>       --file-system-type LUSTRE \
>       --file-system-type-version 2.12 \
>       --lustre-configuration DeploymentType=PERSISTENT_2,PerUnitStorageThroughput=125,DataCompressionType=LZ4 \
>           RootSquashConfiguration={RootSquash="65534:65534", \
>           NoSquashNids=["10.216.123.47@tcp", "10.216.12.176@tcp"]} \
>       --storage-capacity 1200 \
>       --subnet-ids subnet-123456\
>       --tags Key=Name,Value=Lustre-TEST-1 \
>       --region us-east-2 

usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]
To see help text, you can run:

  aws help
  aws <command> help
  aws <command> <subcommand> help

Unknown options: NoSquashNids=[10.216.123.47@tcp,, 10.216.12.176@tcp]}, RootSquashConfiguration={RootSquash=65534:65534,


[cloudshell-user@ip-10-0-112-5 ~]$ aws fsx update-file-system --file-system-id fs-0123456789abcdef0 --lustre-configuration RootSquashConfiguration={RootSquash="65534:65534", NoSquashNids=["10.216.123.47@tcp", "10.216.12.176@tcp"]}

usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]
To see help text, you can run:

  aws help
  aws <command> help
  aws <command> <subcommand> help

Unknown options: 10.216.12.176@tcp]}, NoSquashNids=[10.216.123.47@tcp,

```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
